### PR TITLE
Add terraform and lambda setup for bedrock agent

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,37 @@
+name: Terraform
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r lambda/requirements.txt
+
+      - name: Package Lambda
+        run: |
+          cd lambda
+          zip -r ../lambda.zip .
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Plan
+        run: terraform -chdir=terraform plan
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform -chdir=terraform apply -auto-approve

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,13 +1,13 @@
 name: Terraform
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ closed ]
 
 jobs:
   terraform:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,5 +33,4 @@ jobs:
         run: terraform -chdir=terraform plan
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform -chdir=terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ terraform -chdir=terraform apply
 
 ### GitHub Actions workflow
 
-The workflow defined in `.github/workflows/terraform.yml` automatically packages the Lambda code, initializes Terraform and applies the configuration when changes are pushed to the `main` branch.
+The workflow defined in `.github/workflows/terraform.yml` automatically packages the Lambda code, initializes Terraform and applies the configuration after a pull request is merged into the `main` branch.
 
 ### Lambda function
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# aws-bedrock-agent-codex
+# AWS Bedrock Agent Codex
+
+This repository provides an example project for deploying an AWS Bedrock Agent using **Terraform** and **GitHub Actions**. It also includes a sample Python Lambda function that the agent can invoke to perform custom actions.
+
+## Project structure
+
+```
+.
+├── lambda/                # Python source code for the Lambda function
+│   ├── app.py             # Lambda handler
+│   └── requirements.txt   # Python dependencies
+├── terraform/             # Terraform configuration to deploy the agent and Lambda
+│   ├── main.tf
+│   ├── outputs.tf
+│   ├── provider.tf
+│   └── variables.tf
+└── .github/workflows/     # GitHub Actions workflows
+    └── terraform.yml      # CI/CD pipeline
+```
+
+### Terraform
+
+The Terraform configuration creates an IAM role, deploys the Lambda function and provides a placeholder for future Bedrock Agent resources. Customize `terraform/main.tf` once the Bedrock Agent Terraform resources become available.
+
+Run the following commands locally to deploy:
+
+```bash
+terraform -chdir=terraform init
+terraform -chdir=terraform plan
+terraform -chdir=terraform apply
+```
+
+### GitHub Actions workflow
+
+The workflow defined in `.github/workflows/terraform.yml` automatically packages the Lambda code, initializes Terraform and applies the configuration when changes are pushed to the `main` branch.
+
+### Lambda function
+
+The sample Lambda function located in `lambda/app.py` simply logs the incoming event and returns a JSON payload. Extend this file with any custom logic needed by your Bedrock Agent.
+
+## Getting started
+
+1. Ensure you have [Terraform](https://www.terraform.io/downloads.html) installed.
+2. Configure AWS credentials in your environment (e.g., using `aws configure`).
+3. Package the Lambda function and apply the Terraform configuration.
+
+This setup demonstrates how infrastructure as code and automation can be combined to manage Bedrock Agents on AWS.

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -1,0 +1,9 @@
+import json
+
+def lambda_handler(event, context):
+    """Sample Lambda handler for Bedrock Agent operations."""
+    print("Received event:", json.dumps(event))
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"message": "Hello from Bedrock agent"})
+    }

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,0 +1,2 @@
+# Add Python dependencies here
+boto3

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,33 @@
+resource "aws_iam_role" "lambda_role" {
+  name = "bedrock_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_lambda_function" "agent_function" {
+  function_name = "bedrock_agent_function"
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "app.lambda_handler"
+  runtime       = "python3.11"
+  filename      = var.lambda_zip_path
+  source_code_hash = filebase64sha256(var.lambda_zip_path)
+  timeout       = 30
+}
+
+# Placeholder for Bedrock Agent configuration. Replace with appropriate
+# resources once the Terraform provider supports them.
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "lambda_function_name" {
+  value = aws_lambda_function.agent_function.function_name
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.4.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "lambda_zip_path" {
+  description = "Path to the packaged Lambda zip file"
+  type        = string
+  default     = "../lambda/lambda.zip"
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration with a sample Lambda function
- add GitHub Actions workflow to package Lambda and run Terraform
- document project layout and usage in README

## Testing
- `python -m py_compile lambda/app.py`
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684311d3668c8331925e655a9a27ecc9